### PR TITLE
Short term fix for link leading to a dead end.

### DIFF
--- a/MicrosoftSearch/licensing.md
+++ b/MicrosoftSearch/licensing.md
@@ -23,8 +23,9 @@ This article is for Global or Billing Admins who want to learn about how to purc
 Any valid **Microsoft 365 or Office 365 license** allows you to view data from connectors in your search results.
 
 > [!TIP]
-> **Microsoft Graph connectors & Viva Topics Trial Now Available**:
-> If you don't have index quota available and want to try Microsoft Graph connectors now you can request a **Promo code** with [Microsoft Viva Topics](https://www.microsoft.com/microsoft-viva/topics?activetab=pivot:overviewtab), as detailed [here](#microsoft-graph-connectors-now-available-with-microsoft-viva-topics-trial).
+> **Microsoft Graph connectors promo code**:
+> If you don't have index quota available and want to try Microsoft Graph connectors, now you can request a **Promo code** from your Microsoft account manager. With the promo code you will get a six month trial.
+
 
 >[!IMPORTANT]
 >All of the Graph connectors by Microsoft are free. However, you need to have sufficient index quota to ingest content from those connectors.
@@ -52,16 +53,6 @@ To purchase more Graph connectors quota get in touch with your Microsoft Accoun
 4. Select **Buy** then complete your order preferences.
 5. Select **Check out now**.
 
-## Microsoft Graph connectors now available with Microsoft Viva Topics trial
- The new Viva Topics trial allows you to evaluate both Microsoft Graph connectors and Viva Topics in development and/or production environments. It provides a limited connector capacity in addition to access to Viva Topics.
-
-There are two options to explore Graph connectors with Microsoft Viva Topics:
-
-1. **Start a free trial**, and get access during one month, for 25 users.
-
-     Visit [Microsoft Viva Topics](https://www.microsoft.com/microsoft-viva/topics?activetab=pivot:overviewtab) and select the Free trial option.
-
-2. Contact your Microsoft account manager to request a **Promo code** for trial index capacity with Microsoft Viva Topics trial. With a **Promo code** you can get access during six months, for 50 users.
 
 > [!NOTE]
 > Currently, Microsoft Graph connectors only support up to 7 million items of total index quota, which includes any built-in quota bundled into Microsoft 365 or Office 365 E5 licenses. The platform will support higher limits in the future. Please contact Microsoft support or your Microsoft account manager if you have any questions.


### PR DESCRIPTION
The option to sign up of for Viva topics free trial has been removed from the Microsoft Viva topics pricing page.