### PR TITLE
Fix scope name in  azure-devops-wiki-connector.md

### DIFF
--- a/MicrosoftSearch/azure-devops-wiki-connector.md
+++ b/MicrosoftSearch/azure-devops-wiki-connector.md
@@ -127,7 +127,7 @@ Mandatory fields | Description | Recommended value
 | Application name     | A unique value that identifies the application that you're authorizing.    | Microsoft Search.|
 | Application website  | The URL of the application that requests access to your Azure DevOps instance during connector setup. (required).| For **Microsoft 365 Enterprise**: https://<span>gcs.office.</span>com/,</br> For **Microsoft 365 Government**: https://<span>gcsgcc.<span>office.com/|
 | Authorization callback URL| A required callback URL that the authorization server redirects to. | For **Microsoft 365 Enterprise**: https://<span>gcs.office.</span>com/v1.0/admin/oauth/callback,</br> For **Microsoft 365 Government**: https://<span>gcsgcc.office.<span>com/v1.0/admin/oauth/callback|
-| Authorized scopes | The scope of access for the application | Select the following scopes: Identity (read), code (read), entitlements (read), project and team (read), Microsoft Graph (read), member entitlement management (read), wiki (read).|
+| Authorized scopes | The scope of access for the application | Select the following scopes: Identity (read), code (read), entitlements (read), project and team (read), Graph (read), member entitlement management (read), wiki (read).|
 
 
 >[!IMPORTANT]

--- a/MicrosoftSearch/azure-devops-wiki-connector.md
+++ b/MicrosoftSearch/azure-devops-wiki-connector.md
@@ -86,7 +86,7 @@ The Azure DevOps Graph connector only indexes content from an ADO organization c
     a. Identity (read) <br>
     b. Code (read) <br>
     c. Entitlements (read) <br>
-    d. Project and team (read) <br>
+    d. Project and Team (read) <br>
     e. Graph (read) <br>
     f. MemberEntitlement Management (read) <br>
     g. Wiki (read)
@@ -127,7 +127,7 @@ Mandatory fields | Description | Recommended value
 | Application name     | A unique value that identifies the application that you're authorizing.    | Microsoft Search.|
 | Application website  | The URL of the application that requests access to your Azure DevOps instance during connector setup. (required).| For **Microsoft 365 Enterprise**: https://<span>gcs.office.</span>com/,</br> For **Microsoft 365 Government**: https://<span>gcsgcc.<span>office.com/|
 | Authorization callback URL| A required callback URL that the authorization server redirects to. | For **Microsoft 365 Enterprise**: https://<span>gcs.office.</span>com/v1.0/admin/oauth/callback,</br> For **Microsoft 365 Government**: https://<span>gcsgcc.office.<span>com/v1.0/admin/oauth/callback|
-| Authorized scopes | The scope of access for the application | Select the following scopes: Identity (read), code (read), entitlements (read), project and team (read), Graph (read), member entitlement management (read), wiki (read).|
+| Authorized scopes | The scope of access for the application | Select the following scopes: Identity (read), Code (read), Entitlements (read), Project and Team (read), Graph (read), Member Entitlement Management (read), Wiki (read).|
 
 
 >[!IMPORTANT]


### PR DESCRIPTION
The scope "Microsoft Graph (read)" doesn't exists in the list. There is only "graph (read)" scope.