### PR TITLE
Update servicenow-knowledge-connector.md

### DIFF
--- a/MicrosoftSearch/servicenow-knowledge-connector.md
+++ b/MicrosoftSearch/servicenow-knowledge-connector.md
@@ -351,4 +351,4 @@ You can change the default values of refresh interval from here if you want to.
 After publishing your connection, you can review the status under the **Data Sources** tab in the [admin center](https://admin.microsoft.com). To learn how to make updates and deletions, see [Manage your connector](./manage-connector.md).
 You can find troubleshooting steps for commonly seen issues [here](./troubleshoot-servicenow-knowledge-connector.md).
 
-If you have issues or want to provide feedback, contact [Microsoft Graph | Support](https://developer.microsoft.com/en-us/graph/support).
+If you have issues or want to provide feedback, Please open ticket with Microsoft Sharepoint Support team.


### PR DESCRIPTION
Fixing the support to be for SPO and not Graph API as per the support boundaries for default connectors : https://supportability.visualstudio.com/M365%20Release%20Announcements/_wiki/wikis/M365-Product-Updates.wiki/336385/Graph-connectors-for-Microsoft-Search?anchor=support-model